### PR TITLE
Require cl-lib before using it!

### DIFF
--- a/elm-test-runner.el
+++ b/elm-test-runner.el
@@ -30,6 +30,7 @@
 
 (require 'compile)
 (require 'ansi-color)
+(require 'cl-lib)
 
 (defgroup elm-test nil
   "elm-test integration"


### PR DESCRIPTION
Fixes an error in the call to cl-loop in elm-test-runner--target-file-for (used to toggle between test and implementation module), caused when the file was compiled without that library being loaded before.

I don't recall seeing this error in Spacemacs, but I did start seeing it after switching to Doom.